### PR TITLE
Removed the defaul nongms builder function in the Singleton module.

### DIFF
--- a/maps-sample/src/main/java/com/omh/android/maps/sample/di/SingletonModule.kt
+++ b/maps-sample/src/main/java/com/omh/android/maps/sample/di/SingletonModule.kt
@@ -16,6 +16,5 @@ class SingletonModule {
         return OmhMapProvider.Builder()
             .addGmsPath(BuildConfig.MAPS_GMS_PATH)
             .addNonGmsPath(BuildConfig.MAPS_NON_GMS_PATH)
-            .addNonGmsPath()
     }
 }


### PR DESCRIPTION
This was adding the default path to the provider and overwriting any work done by the plugin.