### PR TITLE
Fixing sourcePath

### DIFF
--- a/buildSrc/src/main/kotlin/android-base-lib.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-base-lib.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
 val androidSourcesJar by tasks.registering(Jar::class) {
     archiveClassifier.set("sources")
     if (project.plugins.findPlugin("com.android.library") != null) {
-        from("android.sourceSets.main.java.srcDirs")
-        from("android.sourceSets.main.kotlin.srcDirs")
+        from("src/main/java")
+        from("src/main/kotlin")
     } else {
         from("sourceSets.main.java.srcDirs")
         from("sourceSets.main.kotlin.srcDirs")


### PR DESCRIPTION
Hello folks,

I've noticed that the Android OMH client libraries' Gradle scripts in OMH Storage, Maps, and Auth currently don't package source code, hindering debugging and navigation. To address this, I suggest modifying the script as follows:

From:
```kotlin
from("src/main/java")
from("src/main/kotlin")
```
To:
```kotlin
from("android.sourceSets.main.java.srcDirs")
from("android.sourceSets.main.kotlin.srcDirs")
```

However, implementing this might require further adjustments. The Gradle logs are reporting "not found" errors for source directories, as shown:
```
2023-08-16T14:51:11.931-0700 [INFO] [org.gradle.api.internal.file.collections.DirectoryFileTree] file or directory '.../omh-storage-2/storage-api/android.sourceSets.main.java.srcDirs', not found
2023-08-16T14:51:11.933-0700 [INFO] [org.gradle.api.internal.file.collections.DirectoryFileTree] file or directory '.../omh-storage-2/storage-api/android.sourceSets.main.kotlin.srcDirs', not found
```

You can generate the source JAR using:
```
./gradlew --no-daemon --debug storage-api:androidSourcesJar
```

Could the team review and consider this change for a better developer experience? Adding source code to the package would significantly aid debugging. Once this is applied, please update Maven central assets to include the source code

Thank you,
Diego

CC - @prestonlau @rquino 